### PR TITLE
Makes sure to have a reasonable height in the last row, too.

### DIFF
--- a/src/pig.js
+++ b/src/pig.js
@@ -458,6 +458,9 @@
       // images.
       if (rowAspectRatio >= this.minAspectRatio || index + 1 === this.images.length) {
 
+        // Make sure that the last row also has a reasonable height
+        rowAspectRatio = Math.max(rowAspectRatio, this.minAspectRatio);
+        
         // Compute this row's height.
         var totalDesiredWidthOfImages = wrapperWidth - this.settings.spaceBetweenImages * (row.length - 1);
         var rowHeight = totalDesiredWidthOfImages / rowAspectRatio;


### PR DESCRIPTION
Hi Dan,
this is another tiny improvement. If the last row of the grid only has e.g. one image, this image was displayed extremely large compared to the other images.
This fixes this behavior.
Best,
Marco