### PR TITLE
Add support for scrolling elements other than window

### DIFF
--- a/src/pig.js
+++ b/src/pig.js
@@ -73,9 +73,9 @@
   function _injectStyle(containerId, classPrefix, transitionSpeed) {
 
     var css = (
-      'body {' + 
+      'body {' +
       '  overflow-y: scroll;' +
-      '}' + 
+      '}' +
       '#' + containerId + ' {' +
       '  position: relative;' +
       '}' +
@@ -464,7 +464,7 @@
 
         // Make sure that the last row also has a reasonable height
         rowAspectRatio = Math.max(rowAspectRatio, this.minAspectRatio);
-        
+
         // Compute this row's height.
         var totalDesiredWidthOfImages = wrapperWidth - this.settings.spaceBetweenImages * (row.length - 1);
         var rowHeight = totalDesiredWidthOfImages / rowAspectRatio;
@@ -861,11 +861,11 @@
 
   // Export Pig into the global scope.
   if (typeof define === 'function' && define.amd) {
-    define(Pig);
+    define([], function() { return Pig });
   } else if (typeof module !== 'undefined' && module.exports) {
     module.exports = Pig;
   } else {
     global.Pig = Pig;
   }
 
-}(this));
+}(typeof window !== 'undefined' ? window : this));

--- a/src/pig.js
+++ b/src/pig.js
@@ -73,9 +73,6 @@
   function _injectStyle(containerId, classPrefix, transitionSpeed) {
 
     var css = (
-      'body {' +
-      '  overflow-y: scroll;' +
-      '}' +
       '#' + containerId + ' {' +
       '  position: relative;' +
       '}' +


### PR DESCRIPTION
This adds a new `scroller` option that defaults to `window` but can be an HTML element. This is useful for putting a pig.js in a parent element with `overflow-y: scroll` that can't take up the full width or height of the window.

I also fixed using pig.js with webpack as `import Pig from 'pig.js/src/pig.js';`, as webpack was loading it as an AMD module and trying to execute `Pig()` on import.