### PR TITLE
Add support for custom ProgressiveImage equivalents

### DIFF
--- a/src/pig.js
+++ b/src/pig.js
@@ -203,6 +203,13 @@
       scroller: window,
 
       /**
+       * Type: ProgressiveImage
+       * Default: ProgressiveImage
+       * Description: The type of object used to represent each image in the grid.
+       */
+      imageType: ProgressiveImage,
+
+      /**
        * Type: string
        * Default: 'pig'
        * Description: The prefix associated with this library that should be
@@ -403,7 +410,7 @@
     var progressiveImages = [];
 
     imageData.forEach(function(image, index) {
-      var progressiveImage = new ProgressiveImage(image, index, this);
+      var progressiveImage = new this.settings.imageType(image, index, this);
       progressiveImages.push(progressiveImage);
     }.bind(this));
 

--- a/src/pig.js
+++ b/src/pig.js
@@ -84,7 +84,7 @@
       '  top: 0;' +
       '  margin: 0;' +
       '}' +
-      '.' + classPrefix + '-figure img {' +
+      '.' + classPrefix + '-figure > * {' +
       '  left: 0;' +
       '  position: absolute;' +
       '  top: 0;' +
@@ -94,14 +94,14 @@
       '  transition: ' + (transitionSpeed / 1000) + 's ease opacity;' +
       '  -webkit-transition: ' + (transitionSpeed / 1000) + 's ease opacity;' +
       '}' +
-      '.' + classPrefix + '-figure img.' + classPrefix + '-thumbnail {' +
+      '.' + classPrefix + '-figure > *.' + classPrefix + '-thumbnail {' +
       '  -webkit-filter: blur(30px);' +
       '  filter: blur(30px);' +
       '  left: auto;' +
       '  position: relative;' +
       '  width: auto;' +
       '}' +
-      '.' + classPrefix + '-figure img.' + classPrefix + '-loaded {' +
+      '.' + classPrefix + '-figure > *.' + classPrefix + '-loaded {' +
       '  opacity: 1;' +
       '}'
     );


### PR DESCRIPTION
As it is, pig.js doesn't give you any control over what is rendered on the grid, beyond specifying a filename and aspect ratio for each image. This adds the ability to specify an alternative implementation of `ProgressiveImage` to display images with.

Implementations must still provide the same interface as `ProgressiveImage`, which according to what `Pig` uses is (in TypeScript):

```
interface PigImage {
    aspectRatio: number;
    style: PigImageStyle;

    load(): void;
    hide(): void;
}

// All numbers have units pixels.
interface PigImageStyle {
    width: number;
    height: number;
    translateX: number;
    translateY: number;
    transition: string;
}
```